### PR TITLE
Fix build for x86. Remove duplicate mcmchr from Android.mk. Other implem...

### DIFF
--- a/libc/Android.mk
+++ b/libc/Android.mk
@@ -411,8 +411,6 @@ libc_static_common_src_files += \
     bionic/pthread_create.cpp \
     bionic/pthread_key.cpp \
 
-libc_common_src_files += \
-    bionic/memchr.c
 endif # x86
 
 ifeq ($(TARGET_ARCH),mips)


### PR DESCRIPTION
...ented in arch-x86/x86.mk

Change-Id: I90a562960b214dd02b015d3e2715f711907ae9e8
