### PR TITLE
Remove the dependency on the non-uapi __kernel_nlink_t.

### DIFF
--- a/libc/include/sys/types.h
+++ b/libc/include/sys/types.h
@@ -59,7 +59,6 @@ typedef __kernel_id_t        id_t;
 typedef __kernel_ino_t       ino_t;
 typedef __kernel_key_t       key_t;
 typedef __kernel_mode_t      mode_t;
-typedef __kernel_nlink_t	 nlink_t;
 #ifndef _OFF_T_DEFINED_
 #define _OFF_T_DEFINED_
 typedef __kernel_off_t       off_t;
@@ -68,6 +67,8 @@ typedef __kernel_loff_t      loff_t;
 typedef loff_t               off64_t;  /* GLibc-specific */
 
 typedef __kernel_pid_t		 pid_t;
+
+typedef __nlink_t nlink_t;
 
 /* while POSIX wants these in <sys/types.h>, we
  * declare then in <pthread.h> instead */


### PR DESCRIPTION
The kernel doesn't have an nlink_t; it just uses the equivalent of
uint32_t. We already had a usable __nlink_t in the C library, so
let's just define our nlink_t in terms of __nlink_t, which is what
__nlink_t was meant for anyway.

Note that our struct stat just follows the kernel, and doesn't refer
to nlink_t anyway.

Change-Id: I6f51188d188fab975e286d6f8945fe746200b8d4
